### PR TITLE
Informative warning of `.remove_diacritics()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,4 @@ Suggests:
     rvest (>= 0.3.0),
     stargazer (>= 5.0.0),
     xml2 (>= 1.3.0)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/R/string_util.R
+++ b/R/string_util.R
@@ -16,7 +16,7 @@
 #' Replace diacritical letters(é, ç, ...) with their "plain" versions. This
 #' function can only handle diacritical letters from latin-based alphabets.
 #' Elements in \code{string} containinig non-latin letters (e.g. cyrillic), will
-#' be replaced by \code{NA}.
+#' be replaced by \code{NA} and a warning will be given.
 #'
 #' Reference: https://stackoverflow.com/a/20495866/13542638
 #'
@@ -70,12 +70,19 @@ NULL
   }
 
   # transliterate to ASCII: á->'a, è->`e, ë->"e, â->^a, æ->ae, ç->c, å->a, ...
-  string <- iconv(string, to = "ASCII//TRANSLIT")
+  tstring <- iconv(string, to = "ASCII//TRANSLIT")
 
   # remove "'", "`", "^", """, "~"
-  string <- str_remove_all(string, "['`\\^\"~]")
+  tstring <- str_remove_all(tstring, "['`\\^\"~]")
 
-  if(any(is.na(string))) warning("Some strings could not be transliterated.")
+  if(any(is.na(tstring))) {
+    translit_err <- paste(string[is.na(tstring)], collapse = "\n")
+    wmessage <- paste(
+      "The following strings could not be transliterated:", translit_err,
+      sep = "\n"
+    )
+    warning(wmessage)
+  }
 
-  return(string)
+  return(tstring)
 }

--- a/man/string_utility.Rd
+++ b/man/string_utility.Rd
@@ -44,7 +44,7 @@ and "ü"->"ue". "ß" is diacritical and handled by \code{.remove_diacritics}.
 Replace diacritical letters(é, ç, ...) with their "plain" versions. This
 function can only handle diacritical letters from latin-based alphabets.
 Elements in \code{string} containinig non-latin letters (e.g. cyrillic), will
-be replaced by \code{NA}.
+be replaced by \code{NA} and a warning will be given.
 
 Reference: https://stackoverflow.com/a/20495866/13542638
 }


### PR DESCRIPTION
Print the strings that could not be transliterated with the warning.